### PR TITLE
Add auction-analyser project with CLI, parser, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 .luarc.json
 .luarc.json:Zone.Identifier
+__pycache__/

--- a/README_auction_analyser.md
+++ b/README_auction_analyser.md
@@ -1,0 +1,38 @@
+# Auction Analyser
+
+This project parses WoW SavedVariables Lua files and stores auction data in SQLite. It provides a CLI for ingesting, enriching and analysing data.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+### Ingest
+
+```bash
+auction-analyser ingest --input path/to/MyAddon_auctionHistory.lua --db auctions.db
+```
+
+### Enrich
+
+```bash
+auction-analyser enrich --db auctions.db
+```
+
+### Find Flips
+
+```bash
+auction-analyser find-flips --db auctions.db --min-profit 100
+```
+
+## Project Structure
+
+- `auction_analyser/parser.py` – Lua parsing utilities
+- `auction_analyser/models.py` – SQLAlchemy models and DB helpers
+- `auction_analyser/enrich.py` – Item metadata enrichment
+- `auction_analyser/cli.py` – Command line interface
+- `tests/` – basic tests
+

--- a/auction_analyser/__init__.py
+++ b/auction_analyser/__init__.py
@@ -1,0 +1,2 @@
+"""Auction analyser package."""
+__all__ = ["parser", "models", "cli", "enrich"]

--- a/auction_analyser/cli.py
+++ b/auction_analyser/cli.py
@@ -1,0 +1,52 @@
+import click
+from tqdm import tqdm
+
+from .parser import parse_lua_file, flatten_auctions
+from .models import Auction, get_session
+from .enrich import enrich_items
+
+
+@click.group()
+def cli():
+    """Auction analyser command line interface."""
+    pass
+
+
+@cli.command()
+@click.option('--input', '-i', 'input_path', type=click.Path(exists=True), required=True)
+@click.option('--db', default='auction.db', help='Path to SQLite database')
+def ingest(input_path: str, db: str):
+    """Ingest a Lua SavedVariables file into the database."""
+    session = get_session(db)
+    data = parse_lua_file(input_path)
+    batch = []
+    for row in tqdm(flatten_auctions(data)):
+        batch.append(Auction(**row))
+        if len(batch) >= 1000:
+            session.bulk_save_objects(batch)
+            session.commit()
+            batch.clear()
+    if batch:
+        session.bulk_save_objects(batch)
+        session.commit()
+
+
+@cli.command()
+@click.option('--db', default='auction.db')
+def enrich(db: str):
+    """Fetch item metadata and store it in the database."""
+    session = get_session(db)
+    enrich_items(session)
+
+
+@cli.command('find-flips')
+@click.option('--db', default='auction.db')
+@click.option('--min-profit', default=0, type=float)
+def find_flips(db: str, min_profit: float):
+    """Placeholder flip finder implementation."""
+    session = get_session(db)
+    click.echo('Flip finding logic not yet implemented.')
+
+
+if __name__ == '__main__':
+    cli()

--- a/auction_analyser/enrich.py
+++ b/auction_analyser/enrich.py
@@ -1,0 +1,39 @@
+"""Item enrichment utilities."""
+import logging
+from typing import Iterable
+
+import requests
+from bs4 import BeautifulSoup
+
+from .models import Auction, Item
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_item_name(item_id: int) -> str | None:
+    """Fetch item name from Turtle WoW database."""
+    url = f"https://database.turtle-wow.org/?item={item_id}"
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.warning("Failed to fetch %s: %s", url, exc)
+        return None
+    soup = BeautifulSoup(resp.text, "html.parser")
+    if soup.title:
+        return soup.title.text.split("-")[0].strip()
+    return None
+
+
+def enrich_items(session):
+    """Populate the items table with metadata."""
+    item_ids = [row[0] for row in session.query(Auction.item_id).distinct()]
+    for item_id in item_ids:
+        if session.query(Item).filter_by(item_id=item_id).first():
+            continue
+        name = fetch_item_name(item_id)
+        if not name:
+            continue
+        item = Item(item_id=item_id, name=name)
+        session.add(item)
+    session.commit()

--- a/auction_analyser/models.py
+++ b/auction_analyser/models.py
@@ -1,0 +1,41 @@
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+Base = declarative_base()
+
+class Auction(Base):
+    __tablename__ = 'auctions'
+
+    id = Column(Integer, primary_key=True)
+    scan_id = Column(Integer, index=True)
+    item_id = Column(Integer, index=True)
+    stack_size = Column(Integer)
+    bid_price = Column(Integer)
+    buyout_price = Column(Integer)
+    seller = Column(String)
+    time_left = Column(Integer)
+    timestamp = Column(Integer, index=True)
+
+class Item(Base):
+    __tablename__ = 'items'
+
+    item_id = Column(Integer, primary_key=True)
+    name = Column(String)
+    median_price = Column(Integer)
+    last_seen = Column(Integer)
+
+
+def get_engine(path: str):
+    return create_engine(f'sqlite:///{path}')
+
+
+def init_db(engine):
+    Base.metadata.create_all(engine)
+
+
+def get_session(path: str):
+    engine = get_engine(path)
+    init_db(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()

--- a/auction_analyser/parser.py
+++ b/auction_analyser/parser.py
@@ -1,0 +1,39 @@
+import re
+from typing import Dict, Iterable, Any
+
+from slpp import slpp as lua
+
+
+def parse_lua_file(path: str) -> Dict[str, Any]:
+    """Parse a Lua table dump file into a Python dictionary."""
+    with open(path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Strip variable assignment or 'return'
+    content = re.sub(r'^.*?=\s*', '', content, count=1).strip()
+    if content.startswith('return'):
+        content = content[len('return'):].strip()
+    content = content.rstrip(';')
+    data = lua.decode(content)
+    return data
+
+
+def flatten_auctions(data: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    """Yield flattened auction rows from parsed data."""
+    for scan_id, auctions in data.items():
+        try:
+            scan_id_int = int(scan_id)
+        except ValueError:
+            continue
+        for entry in auctions:
+            row = {
+                'scan_id': scan_id_int,
+                'item_id': entry.get('item_id'),
+                'stack_size': entry.get('stack_size'),
+                'bid_price': entry.get('bid_price'),
+                'buyout_price': entry.get('buyout_price'),
+                'seller': entry.get('seller'),
+                'time_left': entry.get('time_left'),
+                'timestamp': entry.get('timestamp'),
+            }
+            yield row

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "auction-analyser"
+version = "0.1.0"
+description = "CLI tools for analysing WoW auction data"
+authors = [{name = "Aux"}]
+dependencies = [
+    "click",
+    "sqlalchemy",
+    "tqdm",
+    "slpp",
+    "requests",
+    "beautifulsoup4"
+]
+
+[project.scripts]
+auction-analyser = "auction_analyser.cli:cli"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,11 @@
+from auction_analyser.models import get_session, Auction
+
+
+def test_db_insert(tmp_path):
+    db_path = tmp_path / 'test.db'
+    session = get_session(str(db_path))
+    auction = Auction(scan_id=1, item_id=2, stack_size=1, bid_price=10,
+                      buyout_price=20, seller='a', time_left=1, timestamp=123)
+    session.add(auction)
+    session.commit()
+    assert session.query(Auction).count() == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,10 @@
+from auction_analyser.parser import parse_lua_file, flatten_auctions
+
+def test_parse_lua_file(tmp_path):
+    lua_content = 'data = { [1] = { { ["item_id"] = 1, ["stack_size"] = 2, ["bid_price"] = 10, ["buyout_price"] = 20, ["seller"] = "foo", ["time_left"] = 1, ["timestamp"] = 123 } } }'
+    path = tmp_path / 'data.lua'
+    path.write_text(lua_content)
+    data = parse_lua_file(str(path))
+    rows = list(flatten_auctions(data))
+    assert rows
+    assert rows[0]['item_id'] == 1


### PR DESCRIPTION
## Summary
- implement `auction-analyser` Python package
- parse Lua auction data and store to SQLite with SQLAlchemy
- CLI commands for ingesting data and enriching item info
- tests for parser and database insertion
- add `pyproject.toml` with dependencies
- provide README with usage instructions
- ignore `__pycache__`

## Testing
- `pip install sqlalchemy click tqdm requests beautifulsoup4 slpp -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0ecc3c108325943357008074211a